### PR TITLE
Disable Textarea Resize

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -432,3 +432,7 @@ html {
 .hidden {
   display: none;
 }
+
+#comment {
+  resize: none;
+}


### PR DESCRIPTION
**Description**:

This merge request addresses the issue of the resizable **textarea** comment in our application. To maintain layout consistency and improve user experience, the ability for users to resize the **textarea** has been disabled.

**Changes**:

I've updated the `index.css` file to disable the resizing for the **`#comment`** element. This change improves the user interface by ensuring that the comment box maintains a consistent size, which enhances the overall user experience.

```
#comment {
  resize: none;
}
```

**How to Test:**
1. Navigate to the **Contact** section.
2. Try to resize the **textarea**.
3. Confirm that the **textarea** cannot be resized.